### PR TITLE
Fix Odd Node Len on Intermediate Layer

### DIFF
--- a/merkle_tree.go
+++ b/merkle_tree.go
@@ -88,7 +88,12 @@ func buildWithContent(cs []Content) (*Node, []*Node, error) {
 		})
 	}
 	if len(leafs)%2 == 1 {
-		leafs = append(leafs, leafs[len(leafs)-1])
+		duplicate := &Node{
+			Hash: leafs[len(leafs)-1].Hash,
+			C:    leafs[len(leafs)-1].C,
+			leaf: true,
+		}
+		leafs = append(leafs, duplicate)
 		leafs[len(leafs)-1].dup = true
 	}
 	root := buildIntermediate(leafs)
@@ -101,16 +106,20 @@ func buildIntermediate(nl []*Node) *Node {
 	var nodes []*Node
 	for i := 0; i < len(nl); i += 2 {
 		h := sha256.New()
-		chash := append(nl[i].Hash, nl[i+1].Hash...)
+		var left, right int = i, i+1
+		if i+1 == len(nl) {
+			right = i
+		}
+		chash := append(nl[left].Hash, nl[right].Hash...)
 		h.Write(chash)
 		n := &Node{
-			Left:  nl[i],
-			Right: nl[i+1],
+			Left:  nl[left],
+			Right: nl[right],
 			Hash:  h.Sum(nil),
 		}
 		nodes = append(nodes, n)
-		nl[i].Parent = n
-		nl[i+1].Parent = n
+		nl[left].Parent = n
+		nl[right].Parent = n
 		if len(nl) == 2 {
 			return n
 		}

--- a/merkle_tree_test.go
+++ b/merkle_tree_test.go
@@ -64,6 +64,26 @@ var table = []struct {
 	{
 		contents: []Content{
 			TestContent{
+				x: "Hello",
+			},
+			TestContent{
+				x: "Hi",
+			},
+			TestContent{
+				x: "Hey",
+			},
+			TestContent{
+				x: "Greetings",
+			},
+			TestContent{
+				x: "Hola",
+			},
+		},
+		expectedHash: []byte{46, 216, 115, 174, 13, 210, 55, 39, 119, 197, 122, 104, 93, 144, 112, 131, 202, 151, 41, 14, 80, 143, 21, 71, 140, 169, 139, 173, 50, 37, 235, 188},
+	},
+	{
+		contents: []Content{
+			TestContent{
 				x: "123",
 			},
 			TestContent{
@@ -89,6 +109,38 @@ var table = []struct {
 			},
 		},
 		expectedHash: []byte{30, 76, 61, 40, 106, 173, 169, 183, 149, 2, 157, 246, 162, 218, 4, 70, 153, 148, 62, 162, 90, 24, 173, 250, 41, 149, 173, 121, 141, 187, 146, 43},
+	},
+	{
+		contents: []Content{
+			TestContent{
+				x: "123",
+			},
+			TestContent{
+				x: "234",
+			},
+			TestContent{
+				x: "345",
+			},
+			TestContent{
+				x: "456",
+			},
+			TestContent{
+				x: "1123",
+			},
+			TestContent{
+				x: "2234",
+			},
+			TestContent{
+				x: "3345",
+			},
+			TestContent{
+				x: "4456",
+			},
+			TestContent{
+				x: "4456",
+			},
+		},
+		expectedHash: []byte{75, 116, 113, 234, 23, 149, 100, 110, 172, 129, 124, 248, 163, 158, 148, 160, 243, 161, 32, 227, 175, 254, 74, 214, 146, 64, 185, 124, 116, 137, 108, 37},
 	},
 }
 


### PR DESCRIPTION
Fixes an issue when there is an odd number of nodes on an intermediate layer. Also includes a small change to create a deep copy of duplicated nodes if the number of original elements is odd.

Fixes #1 