### PR TITLE
Fix the readme example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ func (t TestContent) CalculateHash() ([]byte, error) {
 
 //Equals tests for equality of two Contents
 func (t TestContent) Equals(other merkletree.Content) (bool, error) {
-  otherTC, ok := other.(TestContent).x
+  otherTC, ok := other.(TestContent)
   if !ok {
     return false, errors.New("value is not of type TestContent")
   }    


### PR DESCRIPTION
Current readme example has an extra `.x` in the Equals function, this PR fixes that.